### PR TITLE
add vis-bpts plugin.

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -11,6 +11,11 @@ const plugins = [
 		"desc": "make backups of current files before saving"
 	},
 	{
+		"name": "vis-bpts",
+		"repo": "https://codeberg.org/shitpostalotl/vis-bpts",
+		"desc": "insert mode using bullet-points for personal note taking"
+	},
+	{
 		"name": "vis-bundle",
 		"repo": "https://repo.or.cz/vis-bundle.git",
 		"desc": "install (and periodically update) vis plugins from Git repos"


### PR DESCRIPTION
A simple plugin for personal note taking.

I submit this plugin in behalve of the author shitpostalotl, because they have no github acount and ask me to do so.

@erf Is there another way to submit plugins? Via email or similar?