### PR TITLE
Remove vis-fzf-open from plugins as it's no longer accessible

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -83,11 +83,6 @@ const plugins = [
 		"desc": "open recently used files with fzf"
 	},
 	{
-		"name": "vis-fzf-open",
-		"repo": "https://git.sr.ht/~mcepl/vis-fzf-open",
-		"desc": "open files with fzf"
-	},
-	{
 		"name": "vis-go",
 		"repo": "https://gitlab.com/timoha/vis-go",
 		"file": "vis-go",


### PR DESCRIPTION
The upstream URL [1] returns a 404. A brief search reveals that there doesn't seem to be any actively maintained version of the plugin [2]. Please let me know if there's a better way to deal with these scenarios :)

[1]: https://git.sr.ht/~mcepl/vis-fzf-open
[2]: https://sourcegraph.com/search?q=context:global+repo:vis-fzf-open%24&patternType=standard&sm=0