### PR TITLE
add vis-lockfiles plugin

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -114,6 +114,11 @@ const plugins = [
 		"desc": "`gx` jump to the external link (with custom processor, if required), like in the vim’s netrw."
 	},
 	{
+		"name": "vis-lockfiles",
+		"repo": "https://gitlab.com/muhq/vis-lockfiles",
+		"desc": "detect concurrent edits"
+	},
+	{
 		"name": "vis-lspc",
 		"repo": "https://gitlab.com/muhq/vis-lspc",
 		"desc": "language server protocol client"


### PR DESCRIPTION
vis-lockfiles is a plugin managing lock files to detect concurrent edits from multiple vis processes.

Related vis issue: https://github.com/martanne/vis/issues/1169.