### PR TITLE
add vis-editorconfig-options

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -61,6 +61,11 @@ const plugins = [
 		"desc": "automatically parse and apply `.editorconfig` files"
 	},
 	{
+		"name": "vis-editorconfig-options",
+		"repo": "https://github.com/milhnl/vis-editorconfig-options",
+		"desc": ".editorconfig support without external dependencies"
+	},
+	{
 		"name": "vis-eval",
 		"repo": "https://codeberg.org/wf/vis-eval",
 		"desc": "evaluate an arbitrary piece of Lua"


### PR DESCRIPTION
`vis-editorconfig-options` does not depend on `editorconfig-core`.